### PR TITLE
Add a 'set' method to the ZopeCookieSession

### DIFF
--- a/zope2/sessioncookie/__init__.py
+++ b/zope2/sessioncookie/__init__.py
@@ -47,6 +47,9 @@ def _getSessionClass():
             def __guarded_delitem__(self, key):
                 del self[key]
 
+            def set(self, key, value):
+                self[key] = value
+
         InitializeClass(ZopeCookieSession)
 
     return ZopeCookieSession

--- a/zope2/sessioncookie/tests/test___init__.py
+++ b/zope2/sessioncookie/tests/test___init__.py
@@ -63,6 +63,14 @@ class Test__getSessionClass(_Base):
         request._response_callbacks[0](request, response)
         self.assertEqual(response.counter, 1)
 
+    def test_session_class_set_method(self):
+        self._setUpUtility()
+        klass = self._callFUT()
+        request = _Request()
+        session = klass(request)
+        session.set('foo', 'bar')
+        self.assertEqual(session.__guarded_getitem__('foo'), 'bar')
+
 
 class SignedSessionCookieCreatedTests(unittest.TestCase):
 


### PR DESCRIPTION
This is expected by external APIs including PluggableAuthService
